### PR TITLE
Implement UUID-based memo storage

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,5 @@
 This repository demonstrates simple Python classes.
 
-memo.py provides a `Memo` dataclass and a `MemoStore` class that saves memo entries to JSON under `./data/memos.json`.
-
+`memo.py` defines a `Memo` dataclass and a `MemoStore` that stores each memo in
+a separate file under the `./data` directory. Each memo is identified by a UUID,
+so updates and deletions are performed using that ID.


### PR DESCRIPTION
## Summary
- refactor `MemoStore` so each memo lives in its own file named `<uuid>.txt`
- add update and delete helpers that work by UUID
- adjust README to document the new design

## Testing
- `python - <<'PY'
from memo import MemoStore
store = MemoStore()
id1 = store.add_memo('first note')
print('created', id1)
print('list', store.list_memos())
print('get', store.get_memo(id1))
store.update_memo(id1, 'updated note')
print('updated', store.get_memo(id1))
store.delete_memo(id1)
print('deleted list', store.list_memos())
PY`